### PR TITLE
Add additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,102 @@
+linters-settings:
+  dupl:
+    threshold: 150
+  funlen:
+    lines: 100
+    statements: 50
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+      - wrapperFunc
+      - unnamedResult
+  gocognit:
+    min-complexity: 30
+  goimports:
+    local-prefixes: github.com/Mellanox/ipoib-cni
+  golint:
+    min-confidence: 0
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+    settings:
+      printf:
+        funcs:
+          - (github.com/rs/zerolog/zerolog.Event).Msgf
+  lll:
+    line-length: 120
+  misspell:
+    locale: US
+  prealloc:
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocognit
+    - gofmt
+    - goimports
+    - golint 
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gomnd
+        - goconst
+    - text: "Magic number: 1"
+      linters:
+        - gomnd

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_script:
   - go get github.com/mattn/goveralls
 
 script:
-  - make fmt
   - make lint
   - make test-coverage
   - goveralls -coverprofile=ipoib-cni.cover -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,16 @@ IMAGE_BUILD_OPTS += $(DOCKERARGS)
 
 # Go tools
 GO      = go
-GOFMT   = gofmt
-GOLINT = $(GOBIN)/golangci-lint
+GOLANGCI_LINT = $(GOBIN)/golangci-lint
+# golangci-lint version should be updated periodically
+# we keep it fixed to avoid it from unexpectedly failing on the project
+# in case of a version bump
+GOLANGCI_LINT_VER = v1.23.8
 TIMEOUT = 15
-V = 0
 Q = $(if $(filter 1,$V),,@)
 
 .PHONY: all
-all: fmt lint build
+all: lint build
 
 $(BASE): ; $(info  setting GOPATH...)
 	@mkdir -p $(dir $@)
@@ -60,14 +62,8 @@ $(BUILDDIR)/$(BINARY_NAME): $(GOFILES) | $(BUILDDIR)
 
 # Tools
 
-.PHONY: fmt
-fmt: ; $(info  running gofmt...) @ ## Run gofmt on all source files
-	@ret=0 && for d in $$($(GO) list -f '{{.Dir}}' ./... | grep -v /vendor/); do \
-		$(GOFMT) -l -w $$d/*.go || ret=$$? ; \
-	 done ; exit $$ret
-
-$(GOLINT): | $(BASE) ; $(info  building golangci-lint...)
-	$Q go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+$(GOLANGCI_LINT): | $(BASE) ; $(info  building golangci-lint...)
+	$Q curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCI_LINT_VER)
 
 GOVERALLS = $(GOBIN)/goveralls
 $(GOBIN)/goveralls: | $(BASE) ; $(info  building goveralls...)
@@ -76,11 +72,11 @@ $(GOBIN)/goveralls: | $(BASE) ; $(info  building goveralls...)
 # Tests
 
 .PHONY: lint
-lint: | $(BASE) $(GOLINT) ; $(info  running golint...) @ ## Run lint test
+lint: | $(BASE) $(GOLANGCI_LINT) ; $(info  running golangci-lint...) @ ## Run golangci-lint
 	$Q mkdir -p $(BASE)/test
 	$Q cd $(BASE) && ret=0 && \
-		test -z "$$($(GOLINT) run | tee $(BASE)/test/lint.out)" || ret=1 ; \
-		cat $(BASE)/test/lint.out; rm -rf $(BASE)/test; \
+		test -z "$$($(GOLANGCI_LINT) run | tee $(BASE)/test/lint.out)" || ret=1 ; \
+		cat $(BASE)/test/lint.out ; rm -rf $(BASE)/test ; \
 	 exit $$ret
 
 TEST_TARGETS := test-default test-bench test-short test-verbose test-race
@@ -91,10 +87,10 @@ test-verbose: ARGS=-v            ## Run tests in verbose mode with coverage repo
 test-race:    ARGS=-race         ## Run tests with race detector
 $(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
 $(TEST_TARGETS): test
-check test tests: fmt lint | $(BASE) ; $(info  running $(NAME:%=% )tests...) @ ## Run tests
+check test tests: lint | $(BASE) ; $(info  running $(NAME:%=% )tests...) @ ## Run tests
 	$Q cd $(BASE) && $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-test-xml: fmt lint | $(BASE) $(GO2XUNIT) ; $(info  running $(NAME:%=% )tests...) @ ## Run tests with xUnit output
+test-xml: lint | $(BASE) $(GO2XUNIT) ; $(info  running $(NAME:%=% )tests...) @ ## Run tests with xUnit output
 	$Q cd $(BASE) && 2>&1 $(GO) test -timeout 20s -v $(TESTPKGS) | tee test/tests.output
 	$(GO2XUNIT) -fail -input test/tests.output -output test/tests.xml
 

--- a/pkg/ipoib/ipoib_test.go
+++ b/pkg/ipoib/ipoib_test.go
@@ -2,13 +2,15 @@ package ipoib
 
 import (
 	"errors"
-	"github.com/Mellanox/ipoib-cni/pkg/types"
-	"github.com/Mellanox/ipoib-cni/pkg/types/mocks"
+
 	"github.com/containernetworking/plugins/pkg/ns"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
+
+	"github.com/Mellanox/ipoib-cni/pkg/types"
+	"github.com/Mellanox/ipoib-cni/pkg/types/mocks"
 )
 
 // FakeLink is a dummy netlink struct used during testing


### PR DESCRIPTION
- Enable additional golangci linters via configuration file
- Deal with lint issues
- remove fmt check from travis as its now part of lint tag
- sort import order to be builtin, 3rd party, local