### PR TITLE
Add cni version flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /usr/src/ipoib-cni
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --update --virtual build-dependencies build-base linux-headers && \
+RUN apk add --update --virtual build-dependencies build-base linux-headers git && \
     cd /usr/src/ipoib-cni && \
     make clean && \
     make build

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XT
 export GOPATH
 export GOBIN
 
+# Version
+VERSION?=master
+DATE=`date -Iseconds`
+COMMIT?=`git rev-parse --verify HEAD`
+LDFLAGS="-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
+
 # Docker
 IMAGE_BUILDER?=@docker
 IMAGEDIR=$(BASE)/images
@@ -58,7 +64,7 @@ build: $(BUILDDIR)/$(BINARY_NAME) ; $(info Building $(BINARY_NAME)...) ## Build 
 	$(info Done!)
 
 $(BUILDDIR)/$(BINARY_NAME): $(GOFILES) | $(BUILDDIR)
-	@cd $(BASE)/cmd/$(BINARY_NAME) && CGO_ENABLED=0 $(GO) build -o $(BUILDDIR)/$(BINARY_NAME) -tags no_openssl -v
+	@cd $(BASE)/cmd/$(BINARY_NAME) && CGO_ENABLED=0 $(GO) build -o $(BUILDDIR)/$(BINARY_NAME) -tags no_openssl -ldflags $(LDFLAGS)  -v
 
 # Tools
 


### PR DESCRIPTION
When run the ipoib-cni with flag -v or --version it will show the
branch of the build, commit id, and the build data in the format:
"ipoib-cni version:<branch>, commit:<commit id>, date:<build-date>"