### PR TITLE
Set Pkey and Mode with Parent interface values

### DIFF
--- a/pkg/ipoib/ipoib_test.go
+++ b/pkg/ipoib/ipoib_test.go
@@ -82,8 +82,9 @@ var _ = Describe("IPoIB", func() {
 
 	Context("Checking CreateIpoibLink function", func() {
 		var (
-			ifName  string
-			netconf *types.NetConf
+			ifName         string
+			netconf        *types.NetConf
+			fakeMasterLink *netlink.IPoIB
 		)
 
 		BeforeEach(func() {
@@ -91,80 +92,95 @@ var _ = Describe("IPoIB", func() {
 			netconf = &types.NetConf{
 				Master: "ib0",
 			}
+			fakeMasterLink = &netlink.IPoIB{LinkAttrs: netlink.NewLinkAttrs(), Pkey: 0xffff, Mode: netlink.IPOIB_MODE_DATAGRAM}
 		})
 
 		It("Assuming create link and move it to container", func() {
 			targetNetNS := newFakeNs()
-
 			mocked := &mocks.NetlinkManager{}
 			fakeLink := &FakeLink{}
 
+			mocked.On("LinkByName", netconf.Master).Return(fakeMasterLink, nil)
+			mocked.On("LinkAdd", mock.MatchedBy(func(l *netlink.IPoIB) bool {
+				return l.Pkey == (fakeMasterLink.Pkey&0x7fff) && l.Mode == fakeMasterLink.Mode
+			})).Return(nil)
 			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
-			mocked.On("LinkAdd", mock.Anything).Return(nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
-			mocked.On("LinkDel", mock.Anything).Return(nil)
 			mocked.On("SetSysVal", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, mock.AnythingOfType("string")).Return(nil)
 			mocked.On("LinkSetUp", fakeLink).Return(nil)
+
 			im := ipoibManager{nLink: mocked}
 			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
+
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ipoibLink).NotTo(BeNil())
+			mocked.AssertExpectations(GinkgoT())
 		})
 		It("Assuming not existing master", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}
 
-			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(nil, errors.New("not found"))
+			mocked.On("LinkByName", netconf.Master).Return(nil, errors.New("not found"))
 			im := ipoibManager{nLink: mocked}
 			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
+
 			Expect(err).To(HaveOccurred())
 			Expect(ipoibLink).To(BeNil())
+			mocked.AssertExpectations(GinkgoT())
 		})
 		It("Assuming failed to create link", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}
-			fakeLink := &FakeLink{}
 
-			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("LinkByName", netconf.Master).Return(fakeMasterLink, nil)
 			mocked.On("LinkAdd", mock.Anything).Return(errors.New("failed"))
 			im := ipoibManager{nLink: mocked}
 			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
 			Expect(err).To(HaveOccurred())
 			Expect(ipoibLink).To(BeNil())
+
+			mocked.AssertExpectations(GinkgoT())
 		})
 		It("Assuming failed to set proxy value", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}
 			fakeLink := &FakeLink{}
 
-			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("LinkByName", netconf.Master).Return(fakeMasterLink, nil)
 			mocked.On("LinkAdd", mock.Anything).Return(nil)
+			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
 			mocked.On("LinkDel", mock.Anything).Return(nil)
 			mocked.On("SetSysVal", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", errors.New("failed"))
+
 			im := ipoibManager{nLink: mocked}
 			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
+
 			Expect(err).To(HaveOccurred())
 			Expect(ipoibLink).To(BeNil())
+			mocked.AssertExpectations(GinkgoT())
 		})
 		It("Assuming failed to change name", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}
 			fakeLink := &FakeLink{}
 
-			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("LinkByName", netconf.Master).Return(fakeMasterLink, nil)
 			mocked.On("LinkAdd", mock.Anything).Return(nil)
+			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
-			mocked.On("LinkDel", mock.Anything).Return(nil)
 			mocked.On("SetSysVal", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", nil)
 			mocked.On("LinkSetDown", fakeLink).Return(nil)
 			mocked.On("LinkSetName", fakeLink, mock.AnythingOfType("string")).Return(errors.New("failed"))
+			mocked.On("LinkDel", mock.Anything).Return(nil)
+
 			im := ipoibManager{nLink: mocked}
 			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
 			Expect(err).To(HaveOccurred())
 			Expect(ipoibLink).To(BeNil())
+			mocked.AssertExpectations(GinkgoT())
 		})
 	})
 	Context("Checking RemoveIpoibLink function", func() {
@@ -179,23 +195,28 @@ var _ = Describe("IPoIB", func() {
 		It("Assuming existing interface", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}
-
 			fakeLink := &FakeLink{netlink.LinkAttrs{}}
 
 			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mocked.On("LinkDel", fakeLink).Return(nil)
+
 			im := ipoibManager{nLink: mocked}
 			err := im.RemoveIpoibLink(ifName, targetNetNS)
+
 			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertExpectations(GinkgoT())
 		})
 		It("Assuming non existing interface, failed after add", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}
 
 			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(nil, errors.New("not found"))
+
 			im := ipoibManager{nLink: mocked}
 			err := im.RemoveIpoibLink(ifName, targetNetNS)
+
 			Expect(err).NotTo(HaveOccurred())
+			mocked.AssertExpectations(GinkgoT())
 		})
 		It("Assuming existing interface and failed to remove", func() {
 			targetNetNS := newFakeNs()
@@ -204,9 +225,12 @@ var _ = Describe("IPoIB", func() {
 
 			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mocked.On("LinkDel", fakeLink).Return(errors.New("failed to remove"))
+
 			im := ipoibManager{nLink: mocked}
 			err := im.RemoveIpoibLink(ifName, targetNetNS)
+
 			Expect(err).To(HaveOccurred())
+			mocked.AssertExpectations(GinkgoT())
 		})
 	})
 })


### PR DESCRIPTION
This commit derives Pkey and Mode values of ipoib
child interface from parent in order to support
cases where the default pkey and mode is not
0x7fff and datagram respectively.

- use netlink to get parent pkey and mode
- fixup and tune unit-tests