### PR TITLE
feat: add MTU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Allow user to create IPoIB child link and move it to the pod.
 	"name": "mynet",
 	"type": "ipoib",
 	"master": "ib0",
+	"mtu": 1496,
 	"ipam": {
         "type": "host-local",
         "subnet": "192.168.2.0/24",
@@ -31,6 +32,7 @@ Allow user to create IPoIB child link and move it to the pod.
 * `name` (string, required): the name of the network
 * `type` (string, required): "ipoib"
 * `master` (string, required): name of the host interface to create the link from
+* `mtu` (integer, optional): MTU to set on the IPoIB interface inside the container. Must not exceed the master interface MTU. If omitted, the master interface MTU is inherited.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network. For interface only without ip address, create empty dictionary, `dhcp` type is not supported.
 
 ## Limitations

--- a/pkg/ipoib/ipoib.go
+++ b/pkg/ipoib/ipoib.go
@@ -73,6 +73,11 @@ func (n *netLink) LinkDel(link netlink.Link) error {
 	return netlink.LinkDel(link)
 }
 
+// LinkSetMTU using NetlinkManager
+func (n *netLink) LinkSetMTU(link netlink.Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
+}
+
 // SetSysVal set value for sysctl attribute
 func (n *netLink) SetSysVal(attribute, value string) (string, error) {
 	return sysctl.Sysctl(attribute, value)
@@ -153,6 +158,12 @@ func (im *ipoibManager) CreateIpoibLink(conf *types.NetConf, ifName string, netn
 		if innerErr := im.nLink.LinkSetName(link, ifName); innerErr != nil {
 			_ = im.nLink.LinkDel(ipoibLink)
 			return fmt.Errorf("failed to rename interface to %q: %v", ifName, innerErr)
+		}
+		if conf.MTU > 0 {
+			if innerErr := im.nLink.LinkSetMTU(link, conf.MTU); innerErr != nil {
+				_ = im.nLink.LinkDel(ipoibLink)
+				return fmt.Errorf("failed to set MTU %d on interface %q: %v", conf.MTU, ifName, innerErr)
+			}
 		}
 		if innerErr := im.nLink.LinkSetUp(link); innerErr != nil {
 			return innerErr

--- a/pkg/ipoib/ipoib_test.go
+++ b/pkg/ipoib/ipoib_test.go
@@ -162,6 +162,54 @@ var _ = Describe("IPoIB", func() {
 			Expect(ipoibLink).To(BeNil())
 			mocked.AssertExpectations(GinkgoT())
 		})
+		It("Assuming create link with MTU", func() {
+			targetNetNS := newFakeNs()
+			mocked := &mocks.NetlinkManager{}
+			fakeLink := &FakeLink{}
+
+			netconf.MTU = 1496
+			mocked.On("LinkByName", netconf.Master).Return(fakeMasterLink, nil)
+			mocked.On("LinkAdd", mock.MatchedBy(func(l *netlink.IPoIB) bool {
+				return l.Pkey == (fakeMasterLink.Pkey&0x7fff) && l.Mode == fakeMasterLink.Mode
+			})).Return(nil)
+			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			mocked.On("SetSysVal", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, mock.AnythingOfType("string")).Return(nil)
+			mocked.On("LinkSetMTU", fakeLink, 1496).Return(nil)
+			mocked.On("LinkSetUp", fakeLink).Return(nil)
+
+			im := ipoibManager{nLink: mocked}
+			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ipoibLink).NotTo(BeNil())
+			mocked.AssertExpectations(GinkgoT())
+		})
+		It("Assuming failed to set MTU", func() {
+			targetNetNS := newFakeNs()
+			mocked := &mocks.NetlinkManager{}
+			fakeLink := &FakeLink{}
+
+			netconf.MTU = 1496
+			mocked.On("LinkByName", netconf.Master).Return(fakeMasterLink, nil)
+			mocked.On("LinkAdd", mock.Anything).Return(nil)
+			mocked.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+			mocked.On("LinkSetNsFd", fakeLink, mock.AnythingOfType("int")).Return(nil)
+			mocked.On("SetSysVal", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return("", nil)
+			mocked.On("LinkSetDown", fakeLink).Return(nil)
+			mocked.On("LinkSetName", fakeLink, mock.AnythingOfType("string")).Return(nil)
+			mocked.On("LinkSetMTU", fakeLink, 1496).Return(errors.New("failed to set MTU"))
+			mocked.On("LinkDel", mock.Anything).Return(nil)
+
+			im := ipoibManager{nLink: mocked}
+			ipoibLink, err := im.CreateIpoibLink(netconf, ifName, targetNetNS)
+
+			Expect(err).To(HaveOccurred())
+			Expect(ipoibLink).To(BeNil())
+			mocked.AssertExpectations(GinkgoT())
+		})
 		It("Assuming failed to change name", func() {
 			targetNetNS := newFakeNs()
 			mocked := &mocks.NetlinkManager{}

--- a/pkg/types/mocks/NetlinkManager.go
+++ b/pkg/types/mocks/NetlinkManager.go
@@ -61,6 +61,20 @@ func (_m *NetlinkManager) LinkDel(link netlink.Link) error {
 	return r0
 }
 
+// LinkSetMTU provides a mock function with given fields: _a0, _a1
+func (_m *NetlinkManager) LinkSetMTU(_a0 netlink.Link, _a1 int) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(netlink.Link, int) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // LinkSetDown provides a mock function with given fields: _a0
 func (_m *NetlinkManager) LinkSetDown(_a0 netlink.Link) error {
 	ret := _m.Called(_a0)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -27,6 +27,7 @@ import (
 type NetConf struct {
 	types.NetConf
 	Master string `json:"master"`
+	MTU    int    `json:"mtu,omitempty"`
 }
 
 // Manager provides interface invoke ipoib nic related operations
@@ -44,5 +45,6 @@ type NetlinkManager interface {
 	LinkSetNsFd(netlink.Link, int) error
 	LinkAdd(link netlink.Link) error
 	LinkDel(link netlink.Link) error
+	LinkSetMTU(link netlink.Link, mtu int) error
 	SetSysVal(attribute, value string) (string, error)
 }


### PR DESCRIPTION
- Tests are generate via Claude Code.
- MTU configuration is optional. Fabric MTU is set by the SM. Setting it explicitly is useful when the per-pod interface needs to operate below that default.